### PR TITLE
convert2csv

### DIFF
--- a/load_2_mysql.py
+++ b/load_2_mysql.py
@@ -44,8 +44,30 @@ def convert_file_to_csv(load_path='', csv_path=''):
         load_path (str): Path that contains files to be converted.
         csv_path (str): Path where CSV files will be stored.
     """
-    pass
 
+
+# Get all xls and csv files in the load folder
+    file_list = os.listdir(load_path)
+    xls_files = [f for f in file_list if f.endswith('.xls')]
+    csv_files = [f for f in file_list if f.endswith('.csv')]
+
+# Convert xls files to csv and copy csv files to the destination folder
+    for file in xls_files + csv_files:
+        try:
+            if file.endswith('.xls'):
+                df_data = pd.read_excel(os.path.join(load_path, file))
+                filename, ext = os.path.splitext(file)
+                csv_filename = f'{filename}.csv'
+                df_data.to_csv(os.path.join(csv_path, csv_filename), index=None, header=True)
+            elif file.endswith('.csv'):
+                shutil.copyfile(os.path.join(load_path, file), os.path.join(csv_path, file))
+            print(f'{file} has been converted and saved in {csv_path}')
+        except Exception as error:
+            print(error)
+            print(f'An error occurred while processing {file}')
+            sys.exit(0)
+
+    print('Conversion completed successfully!')
 
 def get_column_from_csv(csv_table_files=None, separator_list=None, column_list=None, csv_path=''):
     """Get column names list from csv files.


### PR DESCRIPTION
This function takes two input parameters: load_path and csv_path.

load_path is the path of the directory containing the input Excel (xls) and CSV files to be converted to CSV format.
csv_path is the path of the directory where the converted CSV files will be stored.
The function does the following:

It lists all the Excel (xls) and CSV files in the load_path directory.
It converts all Excel (xls) files to CSV format using the pandas library's read_excel() method.
It copies all CSV files to the csv_path directory using the shutil library's copyfile() method.
It saves the converted CSV files in the csv_path directory.
If an error occurs during the conversion process, the function prints an error message and exits.
Once all files have been processed, the function prints a message indicating that the conversion is complete.